### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/tonyhoffman0837/4fb5f4cd-f70e-4016-88fa-569959d78209/a2265a42-5b12-4f72-823f-e4e6a32e3f80/_apis/work/boardbadge/a1f347f7-f964-4438-aa65-49178ee8a412)](https://dev.azure.com/tonyhoffman0837/4fb5f4cd-f70e-4016-88fa-569959d78209/_boards/board/t/a2265a42-5b12-4f72-823f-e4e6a32e3f80/Microsoft.RequirementCategory)
 # Boards
 board sync test


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/tonyhoffman0837/4fb5f4cd-f70e-4016-88fa-569959d78209/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.